### PR TITLE
Minor edits and fix auction player skip

### DIFF
--- a/README-GET
+++ b/README-GET
@@ -38,7 +38,8 @@ NOTE: this endpoint requires your player cookie to get passed to it
 					      "resource_type": "GAS" || "OIL" || "COAL" || "URANIUM" || "HYBRID" || "CLEAN",
 					      "type": "light" || "dark"
 					    }, ...]
-		}
+		},
+		"can_bid": boolean indicating if they can still bid this turn
 }
 
 --------------------------------------------------------------------------------------------------

--- a/components/game.py
+++ b/components/game.py
@@ -182,7 +182,10 @@ class Game:
 						self.market.buy(pplant["market_cost"])
 			self.next_turn()
 		else:
+			self.auction.advance_bid()
 			self.auction.can_bid.remove(player_id)
+			if self.auction.current_bidder != 0:
+				self.auction.current_bidder -= 1
 			# logger.info("{} passed. Remaining Players: {}".format(player_id, self.auction.can_bid))
 			if len(self.auction.can_bid) == 1:
 				self.auction.auction_in_progress = False
@@ -201,8 +204,6 @@ class Game:
 						if player.player_id == self.player_order[self.current_player]:
 							self.next_turn()
 						break
-			else:
-				self.auction.advance_bid()
 
 
 	def auction_bid(self, player_id, bid, powerplant, trash_id):


### PR DESCRIPTION
Initial changes are minor things. Adding bid status in to the player info, some typos, and better names for python variables. 
The actual big fix comes from selecting the next player in an auction, previously you could skip players and ask someone to bid again on their current bid, usually causing them to pass.
Previously:
a is winning the bid, B is current player 
[a*, B, c] (Current player =1)
b passes, we remove b 
[a*, C] (current player = 1)
We still have people bidding, so we advance the player. The array only has two elements so we loop around making current player 0, meaning A will once again bid on their current bid.
[A*, c] (current player = 0)

Now:
[a*, B, c] (Current player = 1)
b passes, we advance the current player
[a*, b, C] (current player = 2)
we remove b
[a*, c] C (current player = 2)
Then, because the array got smaller, we need to back track one. However, if we looped around, we don;t need to, because every time the 0th player passes, the next one up falls to the 0th slot
[a*, C] (current player = 1)

And now c can decide to bid or pass properly.